### PR TITLE
feat: Add @sardine/lightningcss-plugin-custom-property-fallback

### DIFF
--- a/.changeset/calm-fallback-values.md
+++ b/.changeset/calm-fallback-values.md
@@ -1,5 +1,5 @@
 ---
-"@sardine/lightningcss-plugin-custom-property-fallback": patch
+"@sardine/lightningcss-plugin-custom-property-fallback": major
 ---
 
 Add source custom property values as fallbacks to matching `var()` references.

--- a/.changeset/calm-fallback-values.md
+++ b/.changeset/calm-fallback-values.md
@@ -1,0 +1,5 @@
+---
+"@sardine/lightningcss-plugin-custom-property-fallback": patch
+---
+
+Add source custom property values as fallbacks to matching `var()` references.

--- a/.changeset/shared-source-handle.md
+++ b/.changeset/shared-source-handle.md
@@ -1,5 +1,5 @@
 ---
-"@sardine/lightningcss-plugin-source": minor
+"@sardine/lightningcss-plugin-source": major
 "@sardine/lightningcss-plugin-custom-property-fallback": minor
 "@sardine/lightningcss-plugin-global-custom-queries": minor
 ---

--- a/.changeset/shared-source-handle.md
+++ b/.changeset/shared-source-handle.md
@@ -1,0 +1,7 @@
+---
+"@sardine/lightningcss-plugin-source": minor
+"@sardine/lightningcss-plugin-custom-property-fallback": minor
+"@sardine/lightningcss-plugin-global-custom-queries": minor
+---
+
+Add an explicit shared source handle so multiple plugins can reuse one CSS file read and parse.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3267,12 +3267,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@sardine/lightningcss-plugin-custom-property-fallback": {
+			"resolved": "packages/custom-property-fallback",
+			"link": true
+		},
 		"node_modules/@sardine/lightningcss-plugin-global-composes": {
 			"resolved": "packages/global-composes",
 			"link": true
 		},
 		"node_modules/@sardine/lightningcss-plugin-global-custom-queries": {
 			"resolved": "packages/global-custom-queries",
+			"link": true
+		},
+		"node_modules/@sardine/lightningcss-plugin-source": {
+			"resolved": "packages/source",
 			"link": true
 		},
 		"node_modules/@sardine/lightningcss-plugin-url-composer": {
@@ -7905,6 +7913,23 @@
 				"node": ">=12"
 			}
 		},
+		"packages/custom-property-fallback": {
+			"name": "@sardine/lightningcss-plugin-custom-property-fallback",
+			"version": "0.1.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.5.0",
+				"@sardine/lightningcss-plugin-utils": "*",
+				"@tsconfig/node-lts": "24.0.0",
+				"@tsconfig/strictest": "2.0.8",
+				"@types/node": "24.13.3",
+				"@vitest/coverage-v8": "4.1.10",
+				"lightningcss": "1.32.0",
+				"typescript": "5.9.3",
+				"vite": "8.1.5",
+				"vitest": "4.1.10"
+			}
+		},
 		"packages/global-composes": {
 			"name": "@sardine/lightningcss-plugin-global-composes",
 			"version": "1.2.1",
@@ -7937,6 +7962,26 @@
 				"typescript": "5.9.3",
 				"vite": "8.1.5",
 				"vitest": "4.1.10"
+			}
+		},
+		"packages/source": {
+			"name": "@sardine/lightningcss-plugin-source",
+			"version": "0.0.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.5.0",
+				"@sardine/lightningcss-plugin-utils": "*",
+				"@tsconfig/node-lts": "24.0.0",
+				"@tsconfig/strictest": "2.0.8",
+				"@types/node": "24.13.3",
+				"@vitest/coverage-v8": "4.1.10",
+				"lightningcss": "1.32.0",
+				"typescript": "5.9.3",
+				"vite": "8.1.5",
+				"vitest": "4.1.10"
+			},
+			"peerDependencies": {
+				"lightningcss": ">=1.32.0"
 			}
 		},
 		"packages/url-composer": {

--- a/packages/custom-property-fallback/CHANGELOG.md
+++ b/packages/custom-property-fallback/CHANGELOG.md
@@ -1,0 +1,2 @@
+# @sardine/lightningcss-plugin-custom-property-fallback
+

--- a/packages/custom-property-fallback/README.md
+++ b/packages/custom-property-fallback/README.md
@@ -1,0 +1,7 @@
+# @sardine/lightningcss-plugin-custom-property-fallback
+
+A [Lightning CSS](https://lightningcss.dev/) plugin that does things to CSS.
+
+## Use case
+
+

--- a/packages/custom-property-fallback/README.md
+++ b/packages/custom-property-fallback/README.md
@@ -52,6 +52,30 @@ const { code } = transform({
 });
 ```
 
+### Share a source with other plugins
+
+When multiple plugins read the same CSS file, create one parsed source handle and pass it to each plugin:
+
+```bash
+npm install --save-dev @sardine/lightningcss-plugin-source
+```
+
+```ts
+import { createCssSource } from "@sardine/lightningcss-plugin-source";
+import customPropertyFallback from "@sardine/lightningcss-plugin-custom-property-fallback";
+import globalCustomQueries from "@sardine/lightningcss-plugin-global-custom-queries";
+import { composeVisitors } from "lightningcss";
+
+const source = createCssSource("./src/tokens.css");
+
+const visitor = composeVisitors([
+	globalCustomQueries({ source }),
+	customPropertyFallback({ source }),
+]);
+```
+
+The file is read and parsed once. Each plugin reuses the relevant index from the handle.
+
 ### With Vite
 
 ```ts
@@ -75,7 +99,7 @@ export default defineConfig({
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `source` | `string` | Path to the CSS file containing custom property values. |
+| `source` | `string \| CustomPropertySource` | CSS file path or a shared source handle containing custom property values. |
 
 ## Behavior
 

--- a/packages/custom-property-fallback/README.md
+++ b/packages/custom-property-fallback/README.md
@@ -1,7 +1,90 @@
 # @sardine/lightningcss-plugin-custom-property-fallback
 
-A [Lightning CSS](https://lightningcss.dev/) plugin that does things to CSS.
+A [Lightning CSS](https://lightningcss.dev/) plugin that adds values from a shared custom-property file as `var()` fallbacks. It keeps runtime theming intact while giving each known variable a concrete fallback for browsers or contexts where the custom property is unavailable.
+
+- **Native CSS values.** Fallbacks remain Lightning CSS tokens, including functions, colors, lists, and nested `var()` references.
+- **Non-destructive.** Existing fallbacks are preserved and unknown variables are left unchanged.
+- **Indexed once.** The source file is parsed when the plugin is configured, not once per declaration.
+
+```css
+/* tokens.css */
+:root { --space-md: 16px; }
+
+/* Input */
+.card { margin: var(--space-md); }
+
+/* Output */
+.card { margin: var(--space-md, 16px); }
+```
 
 ## Use case
+
+Keep design tokens in one CSS file while adding their current values as fallbacks throughout component CSS:
+
+```css
+/* tokens.css */
+:root {
+	--space-md: 16px;
+	--card-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+}
+```
+
+The custom property remains in the output, so it can still be overridden at runtime. Only its fallback is added.
+
+## Installation
+
+```bash
+npm install --save-dev @sardine/lightningcss-plugin-custom-property-fallback
+```
+
+## Usage
+
+```ts
+import { composeVisitors, transform } from "lightningcss";
+import customPropertyFallback from "@sardine/lightningcss-plugin-custom-property-fallback";
+
+const { code } = transform({
+	filename: "component.css",
+	code: Buffer.from(".card { margin: var(--space-md); }"),
+	visitor: composeVisitors([
+		customPropertyFallback({ source: "./src/tokens.css" }),
+	]),
+});
+```
+
+### With Vite
+
+```ts
+import { composeVisitors } from "lightningcss";
+import { defineConfig } from "vite";
+import customPropertyFallback from "@sardine/lightningcss-plugin-custom-property-fallback";
+
+export default defineConfig({
+	css: {
+		transformer: "lightningcss",
+		lightningcss: {
+			visitor: composeVisitors([
+				customPropertyFallback({ source: "./src/tokens.css" }),
+			]),
+		},
+	},
+});
+```
+
+## Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `source` | `string` | Path to the CSS file containing custom property values. |
+
+## Behavior
+
+- Custom properties from every selector in the source file are indexed.
+- When a property is declared more than once, the last declaration encountered wins.
+- `var(--name, existing)` keeps its existing fallback.
+- `var(--unknown)` remains unchanged when `--unknown` is absent from the source.
+- Source values may be normalized when Lightning CSS serializes the output, such as converting a color to a shorter equivalent form.
+
+> The source is treated as an ordered token dictionary. The plugin does not reproduce runtime selector specificity, inheritance, media conditions, or other cascade behavior when choosing a fallback.
 
 

--- a/packages/custom-property-fallback/biome.json
+++ b/packages/custom-property-fallback/biome.json
@@ -1,0 +1,4 @@
+{
+	"root": false,
+	"extends": "//"
+}

--- a/packages/custom-property-fallback/package.json
+++ b/packages/custom-property-fallback/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@sardine/lightningcss-plugin-custom-property-fallback",
+	"version": "0.1.0",
+	"description": "A LightningCSS plugin to provide custom property fallbacks",
+	"keywords": [
+		"lightningcss-plugin"
+	],
+	"type": "module",
+	"module": "dist/customPropertyFallback.js",
+	"types": "./dist/customPropertyFallback.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/customPropertyFallback.d.ts",
+			"import": "./dist/customPropertyFallback.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/sardinedev/lightningcss-plugins.git"
+	},
+	"author": "Hugo Nogueira <hnogueira@marabyte.com>",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/sardinedev/lightningcss-plugins/issues"
+	},
+	"homepage": "https://github.com/sardinedev/lightningcss-plugins#readme",
+	"scripts": {
+		"build": "vite build",
+		"test": "vitest run --coverage",
+		"bench": "vitest bench --run",
+		"lint": "biome check --write ./src",
+		"types:check": "tsc -p tsconfig.json",
+		"types:export": "tsc -p tsconfig.export.json"
+	},
+	"devDependencies": {
+		"@sardine/lightningcss-plugin-utils": "*",
+		"@biomejs/biome": "2.5.0",
+		"@tsconfig/node-lts": "24.0.0",
+		"@tsconfig/strictest": "2.0.8",
+		"@types/node": "24.13.3",
+		"@vitest/coverage-v8": "4.1.10",
+		"lightningcss": "1.32.0",
+		"typescript": "5.9.3",
+		"vite": "8.1.5",
+		"vitest": "4.1.10"
+	}
+}

--- a/packages/custom-property-fallback/package.json
+++ b/packages/custom-property-fallback/package.json
@@ -33,7 +33,6 @@
 	"scripts": {
 		"build": "vite build",
 		"test": "vitest run --coverage",
-		"bench": "vitest bench --run",
 		"lint": "biome check --write ./src",
 		"types:check": "tsc -p tsconfig.json",
 		"types:export": "tsc -p tsconfig.export.json"

--- a/packages/custom-property-fallback/src/customPropertyFallback.test.ts
+++ b/packages/custom-property-fallback/src/customPropertyFallback.test.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { composeVisitors, transform } from "lightningcss";
+import { describe, expect, it } from "vitest";
+import customPropertyFallback from "./customPropertyFallback";
+
+const tokens = path.join(__dirname, "./mocks/tokens.css");
+
+/** Run lightningcss transform with the common test defaults. */
+function runTransform<C extends CustomAtRules = CustomAtRules>(source: string, options: Partial<TransformOptions<C>>) {
+	return transform({
+		filename: "test.css",
+		minify: true,
+		code: new TextEncoder().encode(source),
+		...options,
+	});
+}
+
+describe("adds fallback values for custom properties", () => {
+	it("should add fallback values for custom properties", () => {
+		const { code } = runTransform(`.foo { margin-right: var(--space-md); }`, {
+			visitor: composeVisitors([customPropertyFallback({ source: tokens })]),
+		});
+
+		expect(code.toString()).toBe(".foo{margin-right:var(--space-md, 16px);}");
+	});
+});

--- a/packages/custom-property-fallback/src/customPropertyFallback.test.ts
+++ b/packages/custom-property-fallback/src/customPropertyFallback.test.ts
@@ -1,9 +1,12 @@
 import path from "node:path";
+import type { CustomAtRules, TransformOptions } from "lightningcss";
 import { composeVisitors, transform } from "lightningcss";
 import { describe, expect, it } from "vitest";
 import customPropertyFallback from "./customPropertyFallback";
 
 const tokens = path.join(__dirname, "./mocks/tokens.css");
+const missingTokens = path.join(__dirname, "./mocks/missing-tokens.css");
+const ERROR_PREFIX = "[@sardine/lightningcss-plugin-custom-property-fallback]:";
 
 /** Run lightningcss transform with the common test defaults. */
 function runTransform<C extends CustomAtRules = CustomAtRules>(source: string, options: Partial<TransformOptions<C>>) {
@@ -21,6 +24,58 @@ describe("adds fallback values for custom properties", () => {
 			visitor: composeVisitors([customPropertyFallback({ source: tokens })]),
 		});
 
-		expect(code.toString()).toBe(".foo{margin-right:var(--space-md, 16px);}");
+		expect(code.toString()).toBe(".foo{margin-right:var(--space-md,16px)}");
+	});
+
+	it("adds fallbacks to multiple variables", () => {
+		const { code } = runTransform(`.foo { margin: var(--space-sm) var(--space-md); }`, {
+			visitor: composeVisitors([customPropertyFallback({ source: tokens })]),
+		});
+
+		expect(code.toString()).toBe(".foo{margin:var(--space-sm,8px) var(--space-md,16px)}");
+	});
+
+	it("preserves compound source values", () => {
+		const { code } = runTransform(`.foo { box-shadow: var(--card-shadow); }`, {
+			visitor: composeVisitors([customPropertyFallback({ source: tokens })]),
+		});
+
+		expect(code.toString()).toBe(".foo{box-shadow:var(--card-shadow,0 1px 4px #0003)}");
+	});
+
+	it("preserves nested variables in source values", () => {
+		const { code } = runTransform(`.foo { padding: var(--content-spacing); }`, {
+			visitor: composeVisitors([customPropertyFallback({ source: tokens })]),
+		});
+
+		expect(code.toString()).toBe(".foo{padding:var(--content-spacing,var(--space-sm) 24px)}");
+	});
+
+	it("leaves unknown variables unchanged", () => {
+		const { code } = runTransform(`.foo { padding: var(--unknown); }`, {
+			visitor: composeVisitors([customPropertyFallback({ source: tokens })]),
+		});
+
+		expect(code.toString()).toBe(".foo{padding:var(--unknown)}");
+	});
+
+	it("preserves existing fallbacks", () => {
+		const { code } = runTransform(`.foo { padding: var(--space-md, 32px); }`, {
+			visitor: composeVisitors([customPropertyFallback({ source: tokens })]),
+		});
+
+		expect(code.toString()).toBe(".foo{padding:var(--space-md,32px)}");
+	});
+
+	it("uses the last source declaration across selectors", () => {
+		const { code } = runTransform(`.foo { padding: var(--duplicate); }`, {
+			visitor: composeVisitors([customPropertyFallback({ source: tokens })]),
+		});
+
+		expect(code.toString()).toBe(".foo{padding:var(--duplicate,2px)}");
+	});
+
+	it("throws a branded error when the source file cannot be read", () => {
+		expect(() => customPropertyFallback({ source: missingTokens })).toThrowError(ERROR_PREFIX);
 	});
 });

--- a/packages/custom-property-fallback/src/customPropertyFallback.test.ts
+++ b/packages/custom-property-fallback/src/customPropertyFallback.test.ts
@@ -1,7 +1,11 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import type { CustomAtRules, TransformOptions } from "lightningcss";
 import { composeVisitors, transform } from "lightningcss";
 import { describe, expect, it } from "vitest";
+import globalCustomQueries from "../../global-custom-queries/src/globalCustomQueries";
+import { createCssSource } from "../../source/src/source";
 import customPropertyFallback from "./customPropertyFallback";
 
 const tokens = path.join(__dirname, "./mocks/tokens.css");
@@ -25,6 +29,34 @@ describe("adds fallback values for custom properties", () => {
 		});
 
 		expect(code.toString()).toBe(".foo{margin-right:var(--space-md,16px)}");
+	});
+
+	it("reuses a shared source handle", () => {
+		const source = createCssSource(tokens);
+		const { code } = runTransform(`.foo { margin-right: var(--space-md); }`, {
+			visitor: composeVisitors([customPropertyFallback({ source })]),
+		});
+
+		expect(code.toString()).toBe(".foo{margin-right:var(--space-md,16px)}");
+	});
+
+	it("shares one parsed source with another plugin", () => {
+		const directory = mkdtempSync(path.join(tmpdir(), "lightningcss-plugin-source-"));
+		const filename = path.join(directory, "tokens.css");
+
+		try {
+			writeFileSync(filename, "@custom-media --narrow (width <= 40rem); :root { --space-md: 16px; }");
+			const source = createCssSource(filename);
+			rmSync(filename);
+
+			const { code } = runTransform("@media (--narrow) { .foo { margin: var(--space-md); } }", {
+				visitor: composeVisitors([globalCustomQueries({ source }), customPropertyFallback({ source })]),
+			});
+
+			expect(code.toString()).toBe("@media (width<=40rem){.foo{margin:var(--space-md,16px)}}");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 
 	it("adds fallbacks to multiple variables", () => {

--- a/packages/custom-property-fallback/src/customPropertyFallback.ts
+++ b/packages/custom-property-fallback/src/customPropertyFallback.ts
@@ -2,19 +2,23 @@ import { stripNullValues } from "@sardine/lightningcss-plugin-utils";
 import type { CustomProperty, TokenOrValue, Variable } from "lightningcss";
 import { bundle } from "lightningcss";
 
+export interface CustomPropertySource {
+	readonly customProperties: ReadonlyMap<string, TokenOrValue[]>;
+}
+
 export type Options = {
-	/** The path to the CSS file containing custom property fallback values. */
-	source: string;
+	/** A CSS source path or a shared source handle containing custom property fallback values. */
+	source: string | CustomPropertySource;
 };
 
 const ERROR_PREFIX = "[@sardine/lightningcss-plugin-custom-property-fallback]:";
 
-/**
- * Build an index of custom property names to their fallback values from the source CSS file.
- */
-function buildCustomPropertyIndex(source: string): Map<string, TokenOrValue[]> {
-	const customProperties = new Map<string, TokenOrValue[]>();
+function getCustomProperties(source: string | CustomPropertySource): ReadonlyMap<string, TokenOrValue[]> {
+	if (typeof source !== "string") {
+		return source.customProperties;
+	}
 
+	const customProperties = new Map<string, TokenOrValue[]>();
 	try {
 		bundle({
 			filename: source,
@@ -37,7 +41,7 @@ function buildCustomPropertyIndex(source: string): Map<string, TokenOrValue[]> {
  * Add source custom property values as fallbacks to matching `var()` references.
  */
 export default ({ source }: Options) => {
-	const customProperties = buildCustomPropertyIndex(source);
+	const customProperties = getCustomProperties(source);
 
 	return {
 		VariableExit(variable: Variable): TokenOrValue | undefined {

--- a/packages/custom-property-fallback/src/customPropertyFallback.ts
+++ b/packages/custom-property-fallback/src/customPropertyFallback.ts
@@ -1,0 +1,1 @@
+export default ({ source }: Options) => {};

--- a/packages/custom-property-fallback/src/customPropertyFallback.ts
+++ b/packages/custom-property-fallback/src/customPropertyFallback.ts
@@ -1,1 +1,62 @@
-export default ({ source }: Options) => {};
+import { stripNullValues } from "@sardine/lightningcss-plugin-utils";
+import type { CustomProperty, TokenOrValue, Variable } from "lightningcss";
+import { bundle } from "lightningcss";
+
+export type Options = {
+	/** The path to the CSS file containing custom property fallback values. */
+	source: string;
+};
+
+const ERROR_PREFIX = "[@sardine/lightningcss-plugin-custom-property-fallback]:";
+
+/**
+ * Build an index of custom property names to their fallback values from the source CSS file.
+ */
+function buildCustomPropertyIndex(source: string): Map<string, TokenOrValue[]> {
+	const customProperties = new Map<string, TokenOrValue[]>();
+
+	try {
+		bundle({
+			filename: source,
+			visitor: {
+				Declaration: {
+					custom(declaration: CustomProperty) {
+						customProperties.set(declaration.name, stripNullValues(declaration.value));
+					},
+				},
+			},
+		});
+	} catch (error) {
+		throw new Error(`${ERROR_PREFIX} ${(error as Error).message}`);
+	}
+
+	return customProperties;
+}
+
+/**
+ * Add source custom property values as fallbacks to matching `var()` references.
+ */
+export default ({ source }: Options) => {
+	const customProperties = buildCustomPropertyIndex(source);
+
+	return {
+		VariableExit(variable: Variable): TokenOrValue | undefined {
+			if (variable.fallback != null) {
+				return undefined;
+			}
+
+			const fallback = customProperties.get(variable.name.ident);
+			if (!fallback) {
+				return undefined;
+			}
+
+			return {
+				type: "var",
+				value: stripNullValues({
+					...variable,
+					fallback: [...fallback],
+				}),
+			};
+		},
+	};
+};

--- a/packages/custom-property-fallback/src/mocks/tokens.css
+++ b/packages/custom-property-fallback/src/mocks/tokens.css
@@ -1,0 +1,11 @@
+:root {
+	--space-sm: 8px;
+	--space-md: 16px;
+	--card-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+	--content-spacing: var(--space-sm) 24px;
+	--duplicate: 1px;
+}
+
+.theme {
+	--duplicate: 2px;
+}

--- a/packages/custom-property-fallback/tsconfig.export.json
+++ b/packages/custom-property-fallback/tsconfig.export.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "./tsconfig.json",
+	"include": ["./src"],
+	"exclude": ["./src/**/*.test.ts"],
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationDir": "./dist",
+		"emitDeclarationOnly": true
+	}
+}

--- a/packages/custom-property-fallback/tsconfig.json
+++ b/packages/custom-property-fallback/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node-lts/tsconfig.json"],
+	"exclude": ["./dist"],
+	"compilerOptions": {
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"noEmit": true
+	}
+}

--- a/packages/custom-property-fallback/vite.config.ts
+++ b/packages/custom-property-fallback/vite.config.ts
@@ -1,0 +1,27 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+export default defineConfig({
+	test: {
+		coverage: {
+			reporter: ["lcovonly", "text-summary"],
+			include: ["src/**/*.ts"],
+			exclude: ["src/**/*.bench.ts"],
+		},
+		benchmark: {
+			include: ["src/**/*.bench.ts"],
+		},
+	},
+	build: {
+		minify: false,
+		target: "node20",
+		lib: {
+			entry: resolve(__dirname, "src/globalComposes.ts"),
+			formats: ["es"],
+			fileName: "globalComposes",
+		},
+		rollupOptions: {
+			// make sure to externalize deps that shouldn't be bundled
+			external: ["lightningcss", "node:path"],
+		},
+	},
+});

--- a/packages/custom-property-fallback/vite.config.ts
+++ b/packages/custom-property-fallback/vite.config.ts
@@ -15,9 +15,9 @@ export default defineConfig({
 		minify: false,
 		target: "node20",
 		lib: {
-			entry: resolve(__dirname, "src/globalComposes.ts"),
+			entry: resolve(__dirname, "src/customPropertyFallback.ts"),
 			formats: ["es"],
-			fileName: "globalComposes",
+			fileName: "customPropertyFallback",
 		},
 		rollupOptions: {
 			// make sure to externalize deps that shouldn't be bundled

--- a/packages/custom-property-fallback/vite.config.ts
+++ b/packages/custom-property-fallback/vite.config.ts
@@ -7,9 +7,6 @@ export default defineConfig({
 			include: ["src/**/*.ts"],
 			exclude: ["src/**/*.bench.ts"],
 		},
-		benchmark: {
-			include: ["src/**/*.bench.ts"],
-		},
 	},
 	build: {
 		minify: false,

--- a/packages/global-custom-queries/README.md
+++ b/packages/global-custom-queries/README.md
@@ -68,6 +68,30 @@ const { code } = transform({
 });
 ```
 
+### Share a source with other plugins
+
+Use `createCssSource` when this plugin and another Lightning CSS plugin read the same file:
+
+```bash
+npm install --save-dev @sardine/lightningcss-plugin-source
+```
+
+```ts
+import { createCssSource } from "@sardine/lightningcss-plugin-source";
+import customPropertyFallback from "@sardine/lightningcss-plugin-custom-property-fallback";
+import globalCustomQueries from "@sardine/lightningcss-plugin-global-custom-queries";
+import { composeVisitors } from "lightningcss";
+
+const source = createCssSource("./src/tokens.css");
+
+const visitor = composeVisitors([
+  globalCustomQueries({ source }),
+  customPropertyFallback({ source }),
+]);
+```
+
+Both plugins reuse the indexes created by one filesystem read and one parse.
+
 ### With a bundler (e.g. Vite)
 
 ```ts
@@ -91,7 +115,7 @@ export default {
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `source` | `string` | Path to the CSS file containing the `@custom-media` definitions to resolve from. |
+| `source` | `string \| CustomMediaSource` | CSS file path or a shared source handle containing custom media queries. |
 
 ## Supported query shapes
 

--- a/packages/global-custom-queries/src/globalCustomQueries.test.ts
+++ b/packages/global-custom-queries/src/globalCustomQueries.test.ts
@@ -32,6 +32,15 @@ describe("globalCustomQueries", () => {
 		expect(code.toString()).toBe("@media (width<=100em){.foo{color:red}}");
 	});
 
+	it("accepts a shared source handle", () => {
+		const source = { customMedia: new Map() };
+		const { code } = runTransform("@media (--unknown) { .foo { color: red; } }", {
+			visitor: composeVisitors([globalCustomQueries({ source })]),
+		});
+
+		expect(code.toString()).toBe("@media (--unknown){.foo{color:red}}");
+	});
+
 	it("should leave an unknown custom media query unchanged", () => {
 		const source = `
 			@media (--small-breakpoint) {

--- a/packages/global-custom-queries/src/globalCustomQueries.ts
+++ b/packages/global-custom-queries/src/globalCustomQueries.ts
@@ -2,9 +2,13 @@ import { stripNullValues } from "@sardine/lightningcss-plugin-utils";
 import type { Declaration, MediaCondition, MediaQuery, StyleSheet } from "lightningcss";
 import { bundle } from "lightningcss";
 
+export interface CustomMediaSource {
+	readonly customMedia: ReadonlyMap<string, MediaCondition>;
+}
+
 export type Options = {
-	/* The path to the file you want to extract the custom queries from */
-	source: string;
+	/** A CSS source path or a shared source handle containing custom media queries. */
+	source: string | CustomMediaSource;
 };
 
 function returnAST(source: string): StyleSheet<Declaration, MediaQuery> {
@@ -72,17 +76,21 @@ function resolveCondition(condition: MediaCondition, lookup: (name: string) => M
  * );
  */
 export default ({ source }: Options) => {
-	const ast = returnAST(source);
-
-	/** Index of `@custom-media` rule name → resolved condition, built once at setup. */
-	const customMediaMap = new Map<string, MediaCondition>();
-	for (const rule of ast.rules) {
-		if (rule.type === "custom-media") {
-			const condition = rule.value.query.mediaQueries[0]?.condition;
-			if (condition) {
-				customMediaMap.set(rule.value.name, stripNullValues(condition));
+	let customMediaMap: ReadonlyMap<string, MediaCondition>;
+	if (typeof source === "string") {
+		const ast = returnAST(source);
+		const index = new Map<string, MediaCondition>();
+		for (const rule of ast.rules) {
+			if (rule.type === "custom-media") {
+				const condition = rule.value.query.mediaQueries[0]?.condition;
+				if (condition) {
+					index.set(rule.value.name, stripNullValues(condition));
+				}
 			}
 		}
+		customMediaMap = index;
+	} else {
+		customMediaMap = source.customMedia;
 	}
 
 	const lookup = (name: string): MediaCondition | null => customMediaMap.get(name) ?? null;

--- a/packages/source/CHANGELOG.md
+++ b/packages/source/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @sardine/lightningcss-plugin-source

--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -1,0 +1,66 @@
+# @sardine/lightningcss-plugin-source
+
+Parse one CSS source file once and share its indexed values across Lightning CSS plugins. This avoids repeated filesystem reads and parsing when several plugins use the same tokens file.
+
+- **One parse.** `createCssSource()` reads and bundles the source immediately.
+- **Shared indexes.** Custom properties and `@custom-media` definitions are available from one handle.
+- **Explicit lifetime.** The caller owns the handle, so there is no process-global cache or hidden invalidation behavior.
+
+```ts
+const source = createCssSource("./src/tokens.css");
+
+composeVisitors([
+	globalCustomQueries({ source }),
+	customPropertyFallback({ source }),
+]);
+```
+
+## Installation
+
+```bash
+npm install --save-dev @sardine/lightningcss-plugin-source
+```
+
+Install the Lightning CSS plugins that will consume the source handle separately.
+
+## Usage
+
+```ts
+import { createCssSource } from "@sardine/lightningcss-plugin-source";
+import customPropertyFallback from "@sardine/lightningcss-plugin-custom-property-fallback";
+import globalCustomQueries from "@sardine/lightningcss-plugin-global-custom-queries";
+import { composeVisitors, transform } from "lightningcss";
+
+const source = createCssSource("./src/tokens.css");
+
+const { code } = transform({
+	filename: "component.css",
+	code: Buffer.from(`
+		@media (--narrow) {
+			.card { margin: var(--space-md); }
+		}
+	`),
+	visitor: composeVisitors([
+		globalCustomQueries({ source }),
+		customPropertyFallback({ source }),
+	]),
+});
+```
+
+## API
+
+### `createCssSource(filename)`
+
+Reads and parses `filename`, then returns a `CssSource` containing read-only indexes:
+
+- `customMedia`: custom media names mapped to their parsed conditions.
+- `customProperties`: custom property names mapped to their parsed token values.
+- `filename`: the source path used to create the handle.
+
+Custom properties are indexed in source order. When a property appears more than once, the last declaration wins.
+
+### `resolveCssSource(source)`
+
+Returns an existing `CssSource` unchanged or creates one when given a string path. Plugin authors can use this helper when accepting `CssSourceInput` directly.
+
+> The handle is a snapshot. Create a new handle when the source file changes.

--- a/packages/source/biome.json
+++ b/packages/source/biome.json
@@ -1,0 +1,15 @@
+{
+	"root": false,
+	"extends": "//",
+	"linter": {
+		"rules": {
+			"suspicious": {
+				"noUnknownAtRules": {
+					"options": {
+						"ignore": ["custom-media"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,0 +1,55 @@
+{
+	"name": "@sardine/lightningcss-plugin-source",
+	"version": "0.0.0",
+	"description": "A shared CSS source parser for Lightning CSS plugins",
+	"keywords": [
+		"lightningcss-plugin"
+	],
+	"type": "module",
+	"module": "dist/source.js",
+	"types": "./dist/source.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/source.d.ts",
+			"import": "./dist/source.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/sardinedev/lightningcss-plugins.git"
+	},
+	"author": "Hugo Nogueira <hnogueira@marabyte.com>",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/sardinedev/lightningcss-plugins/issues"
+	},
+	"homepage": "https://github.com/sardinedev/lightningcss-plugins#readme",
+	"scripts": {
+		"build": "vite build",
+		"test": "vitest run --coverage",
+		"lint": "biome check --write ./src",
+		"types:check": "tsc -p tsconfig.json",
+		"types:export": "tsc -p tsconfig.export.json"
+	},
+	"peerDependencies": {
+		"lightningcss": ">=1.32.0"
+	},
+	"devDependencies": {
+		"@sardine/lightningcss-plugin-utils": "*",
+		"@biomejs/biome": "2.5.0",
+		"@tsconfig/node-lts": "24.0.0",
+		"@tsconfig/strictest": "2.0.8",
+		"@types/node": "24.13.3",
+		"@vitest/coverage-v8": "4.1.10",
+		"lightningcss": "1.32.0",
+		"typescript": "5.9.3",
+		"vite": "8.1.5",
+		"vitest": "4.1.10"
+	}
+}

--- a/packages/source/src/mocks/tokens.css
+++ b/packages/source/src/mocks/tokens.css
@@ -1,0 +1,10 @@
+@custom-media --narrow (width <= 40rem);
+
+:root {
+	--space-md: 16px;
+	--duplicate: 1px;
+}
+
+.theme {
+	--duplicate: 2px;
+}

--- a/packages/source/src/source.test.ts
+++ b/packages/source/src/source.test.ts
@@ -1,0 +1,38 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createCssSource, resolveCssSource } from "./source";
+
+const tokens = path.join(__dirname, "./mocks/tokens.css");
+const missingTokens = path.join(__dirname, "./mocks/missing-tokens.css");
+const ERROR_PREFIX = "[@sardine/lightningcss-plugin-source]:";
+
+describe("createCssSource", () => {
+	it("indexes custom media and custom properties in one source", () => {
+		const source = createCssSource(tokens);
+
+		expect(source.filename).toBe(tokens);
+		expect(source.customMedia.has("--narrow")).toBe(true);
+		expect(source.customProperties.has("--space-md")).toBe(true);
+	});
+
+	it("uses the last custom property declaration", () => {
+		const source = createCssSource(tokens);
+		const duplicate = source.customProperties.get("--duplicate");
+
+		expect(duplicate).toEqual([{ type: "length", value: { unit: "px", value: 2 } }]);
+	});
+
+	it("reuses an existing source handle", () => {
+		const source = createCssSource(tokens);
+
+		expect(resolveCssSource(source)).toBe(source);
+	});
+
+	it("resolves a source filename", () => {
+		expect(resolveCssSource(tokens).filename).toBe(tokens);
+	});
+
+	it("throws a branded error when the source cannot be read", () => {
+		expect(() => createCssSource(missingTokens)).toThrowError(ERROR_PREFIX);
+	});
+});

--- a/packages/source/src/source.ts
+++ b/packages/source/src/source.ts
@@ -1,0 +1,65 @@
+import { stripNullValues } from "@sardine/lightningcss-plugin-utils";
+import type { CustomProperty, Declaration, MediaCondition, MediaQuery, StyleSheet, TokenOrValue } from "lightningcss";
+import { bundle } from "lightningcss";
+
+const ERROR_PREFIX = "[@sardine/lightningcss-plugin-source]:";
+
+/** Parsed indexes shared by Lightning CSS plugins using the same source file. */
+export interface CssSource {
+	readonly filename: string;
+	readonly customMedia: ReadonlyMap<string, MediaCondition>;
+	readonly customProperties: ReadonlyMap<string, TokenOrValue[]>;
+}
+
+/** A source filename or a source handle created with `createCssSource`. */
+export type CssSourceInput = string | CssSource;
+
+/**
+ * Parse a CSS source file once and index the values used by Lightning CSS plugins.
+ */
+export function createCssSource(filename: string): CssSource {
+	const customProperties = new Map<string, TokenOrValue[]>();
+	let stylesheet!: StyleSheet<Declaration, MediaQuery>;
+
+	try {
+		bundle({
+			filename,
+			drafts: {
+				customMedia: true,
+			},
+			visitor: {
+				StyleSheet(value) {
+					stylesheet = value;
+				},
+				Declaration: {
+					custom(declaration: CustomProperty) {
+						customProperties.set(declaration.name, stripNullValues(declaration.value));
+					},
+				},
+			},
+		});
+	} catch (error) {
+		throw new Error(`${ERROR_PREFIX} ${(error as Error).message}`);
+	}
+
+	const customMedia = new Map<string, MediaCondition>();
+	for (const rule of stylesheet.rules) {
+		if (rule.type === "custom-media") {
+			const condition = rule.value.query.mediaQueries[0]?.condition;
+			if (condition) {
+				customMedia.set(rule.value.name, stripNullValues(condition));
+			}
+		}
+	}
+
+	return Object.freeze({
+		filename,
+		customMedia,
+		customProperties,
+	});
+}
+
+/** Resolve a filename or reuse an existing parsed source handle. */
+export function resolveCssSource(source: CssSourceInput): CssSource {
+	return typeof source === "string" ? createCssSource(source) : source;
+}

--- a/packages/source/tsconfig.export.json
+++ b/packages/source/tsconfig.export.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "./tsconfig.json",
+	"include": ["./src"],
+	"exclude": ["./src/**/*.test.ts"],
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationDir": "./dist",
+		"emitDeclarationOnly": true
+	}
+}

--- a/packages/source/tsconfig.json
+++ b/packages/source/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node-lts/tsconfig.json"],
+	"exclude": ["./dist"],
+	"compilerOptions": {
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"noEmit": true
+	}
+}

--- a/packages/source/vite.config.ts
+++ b/packages/source/vite.config.ts
@@ -1,0 +1,23 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		coverage: {
+			reporter: ["lcovonly", "text-summary"],
+			include: ["src/**/*.ts"],
+		},
+	},
+	build: {
+		minify: false,
+		target: "node20",
+		lib: {
+			entry: resolve(__dirname, "src/source.ts"),
+			formats: ["es"],
+			fileName: "source",
+		},
+		rollupOptions: {
+			external: ["lightningcss"],
+		},
+	},
+});


### PR DESCRIPTION
Adds a new plugin to write fallbacks in CSS custom properties:

```css
/* tokens.css */
:root { --space-md: 16px; }

/* Input */
.card { margin: var(--space-md); }

/* Output */
.card { margin: var(--space-md, 16px); }
```

Also adds a new utility to re-use source CSS files across multiple plugins to avoid reading the same file multiple times 